### PR TITLE
Fix data race on Close

### DIFF
--- a/client.go
+++ b/client.go
@@ -306,13 +306,14 @@ func NewClient(conf ClientConf) (*Client, error) {
 	return c, nil
 }
 
-// Terminate closes every open connection and stops the client.
-func (c *Client) Close() {
+// Close every open connection and stop the client.
+func (c *Client) Close() error {
 	if c.terminateRequested == true {
-		return
+		return nil
 	}
 	c.terminateRequested = true
 	c.terminate <- struct{}{}
+	return nil
 }
 
 // Run starts the client and waits until the client has been terminated.

--- a/protocol.go
+++ b/protocol.go
@@ -22,7 +22,7 @@ type monitoredConnIntf interface {
 }
 
 type protocol interface {
-	Close()
+	Close() error
 	SetSyncMode(val bool)
 	SetReadBinary(val bool)
 	Read() (msgDecodable, error)
@@ -159,9 +159,9 @@ func newProtocolBase(remoteLabel string, nconn net.Conn,
 	return p
 }
 
-func (p *protocolBase) Close() {
+func (p *protocolBase) Close() error {
 	if p.terminated == true {
-		return
+		return nil
 	}
 	p.terminated = true
 	p.closer.Close()
@@ -170,6 +170,7 @@ func (p *protocolBase) Close() {
 		close(p.sendChan)
 		<-p.writerJoined
 	}
+	return nil
 }
 
 func (p *protocolBase) SetSyncMode(val bool) {

--- a/protocol.go
+++ b/protocol.go
@@ -261,7 +261,7 @@ func (p *protocolBase) WriterEnableZlib() {
 }
 
 func (p *protocolBase) WriterDisableZlib() {
-	p.writer.EnableZlib()
+	p.writer.DisableZlib()
 }
 
 type msgBinary struct {


### PR DESCRIPTION
Fixes #3 and changes a `Close` signature to match Go convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gswly/dctoolkit/4)
<!-- Reviewable:end -->
