### PR TITLE
More hooks, configuration and ALPN

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -2,7 +2,7 @@ package dctoolkit
 
 // MessagePublic publishes a message in the hub public chat.
 func (c *Client) MessagePublic(content string) {
-	if c.protoIsAdc == true {
+	if c.protoIsAdc() {
 		c.connHub.conn.Write(&msgAdcBMessage{
 			msgAdcTypeB{c.sessionId},
 			msgAdcKeyMessage{Content: content},
@@ -15,7 +15,7 @@ func (c *Client) MessagePublic(content string) {
 
 // MessagePrivate sends a private message to a specific peer connected to the hub.
 func (c *Client) MessagePrivate(dest *Peer, content string) {
-	if c.protoIsAdc == true {
+	if c.protoIsAdc() {
 		c.connHub.conn.Write(&msgAdcDMessage{
 			msgAdcTypeD{c.sessionId, dest.adcSessionId},
 			msgAdcKeyMessage{Content: content},

--- a/client.go
+++ b/client.go
@@ -234,6 +234,7 @@ func NewClient(conf ClientConf) (*Client, error) {
 	if _, ok := map[string]struct{}{
 		"adc":   {},
 		"adcs":  {},
+		"dchub": {},
 		"nmdc":  {},
 		"nmdcs": {},
 	}[u.Scheme]; !ok {
@@ -253,8 +254,8 @@ func NewClient(conf ClientConf) (*Client, error) {
 	c := &Client{
 		conf:                  conf,
 		terminate:             make(chan struct{}),
-		protoIsAdc:            (u.Scheme == "adc" || u.Scheme == "adcs"),
-		hubIsEncrypted:        (u.Scheme == "adcs" || u.Scheme == "nmdcs"),
+		protoIsAdc:            u.Scheme == "adc" || u.Scheme == "adcs",
+		hubIsEncrypted:        u.Scheme == "adcs" || u.Scheme == "nmdcs",
 		hubHostname:           u.Hostname(),
 		hubPort:               atoui(u.Port()),
 		shareRoots:            make(map[string]string),

--- a/client.go
+++ b/client.go
@@ -165,6 +165,8 @@ type Client struct {
 	OnHubConnected func()
 	// OnHubError is called when a critical error happens
 	OnHubError func(err error)
+	// OnHubInfo is called when an information about the hub is received
+	OnHubInfo func(field HubField, value string)
 	// OnPeerConnected is called when a peer connects to the hub
 	OnPeerConnected func(p *Peer)
 	// OnPeerUpdated is called when a peer has just updated its informations

--- a/client.go
+++ b/client.go
@@ -157,29 +157,29 @@ type Client struct {
 	transfers             map[transfer]struct{}
 	activeDownloadsByPeer map[string]*Download
 
-	// called just after client initialization, before connecting to the hub
+	// OnInitialized is called just after client initialization, before connecting to the hub
 	OnInitialized func()
-	// called every time the share indexer has finished indexing the client share
+	// OnShareIndexed is called every time the share indexer has finished indexing the client share
 	OnShareIndexed func()
-	// called when the connection between client and hub has been established
+	// OnHubConnected is called when the connection between client and hub has been established
 	OnHubConnected func()
-	// called when a critical error happens
+	// OnHubError is called when a critical error happens
 	OnHubError func(err error)
-	// called when a peer connects to the hub
+	// OnPeerConnected is called when a peer connects to the hub
 	OnPeerConnected func(p *Peer)
-	// called when a peer has just updated its informations
+	// OnPeerUpdated is called when a peer has just updated its informations
 	OnPeerUpdated func(p *Peer)
-	// called when a peer disconnects from the hub
+	// OnPeerDisconnected is called when a peer disconnects from the hub
 	OnPeerDisconnected func(p *Peer)
-	// called when someone has written in the hub public chat
+	// OnMessagePublic is called when someone has written in the hub public chat
 	OnMessagePublic func(p *Peer, content string)
-	// called when a private message has been received
+	// OnMessagePrivate is called when a private message has been received
 	OnMessagePrivate func(p *Peer, content string)
-	// called when a search result has been received
+	// OnSearchResult is called when a search result has been received
 	OnSearchResult func(r *SearchResult)
-	// called when a given download has finished
+	// OnDownloadSuccessful is called when a given download has finished
 	OnDownloadSuccessful func(d *Download)
-	// called when a given download has failed
+	// OnDownloadError is called when a given download has failed
 	OnDownloadError func(d *Download)
 }
 

--- a/conn_hub.go
+++ b/conn_hub.go
@@ -21,6 +21,7 @@ const (
 
 type connHub struct {
 	client             *Client
+	name               string
 	terminateRequested bool
 	terminate          chan struct{}
 	state              string
@@ -208,6 +209,7 @@ func (h *connHub) handleMessage(msgi msgDecodable) error {
 			switch key {
 			case adcFieldName:
 				klabel = HubName
+				h.name = val
 			case adcFieldSoftware:
 				klabel = HubSoftware
 			case adcFieldVersion:
@@ -224,6 +226,9 @@ func (h *connHub) handleMessage(msgi msgDecodable) error {
 		}
 
 	case *msgAdcIMsg:
+		if h.client.OnMessagePublic != nil {
+			h.client.OnMessagePublic(&Peer{Nick: h.name}, msg.Content)
+		}
 		dolog(LevelInfo, "[hub] %s", msg.Content)
 
 	case *msgAdcIGetPass:

--- a/conn_hub.go
+++ b/conn_hub.go
@@ -88,7 +88,14 @@ func (h *connHub) do() {
 		// hub connected
 		rawconn := ce.Conn
 		if h.client.hubIsEncrypted == true {
-			rawconn = tls.Client(rawconn, &tls.Config{InsecureSkipVerify: true})
+			next := []string{"adc"}
+			if !h.client.protoIsAdc {
+				next = []string{"nmdc"}
+			}
+			rawconn = tls.Client(rawconn, &tls.Config{
+				InsecureSkipVerify: true,
+				NextProtos:         next,
+			})
 		}
 
 		// do not use read timeout since hub does not send data continuously

--- a/conn_hub_keepalive.go
+++ b/conn_hub_keepalive.go
@@ -29,7 +29,7 @@ func newHubKeepAliver(h *connHub) *hubKeepAliver {
 			case <-ticker.C:
 				// we must call Safe() since conn.Write() is not thread safe
 				h.client.Safe(func() {
-					if h.client.protoIsAdc == true {
+					if h.client.protoIsAdc() {
 						// ADC uses the TCP keepalive feature or empty packets
 						h.conn.Write(&msgAdcKeepAlive{})
 					} else {

--- a/conn_peer.go
+++ b/conn_peer.go
@@ -59,7 +59,7 @@ func newConnPeer(client *Client, isEncrypted bool, isActive bool,
 		if p.isEncrypted == true {
 			p.tlsConn = rawconn.(*tls.Conn)
 		}
-		if client.protoIsAdc == true {
+		if client.protoIsAdc() {
 			p.conn = newProtocolAdc("p", rawconn, true, true)
 		} else {
 			p.conn = newProtocolNmdc("p", rawconn, true, true)
@@ -121,7 +121,7 @@ func (p *connPeer) do() {
 				rawconn = p.tlsConn
 			}
 
-			if p.client.protoIsAdc == true {
+			if p.client.protoIsAdc() {
 				p.conn = newProtocolAdc("p", rawconn, true, true)
 			} else {
 				p.conn = newProtocolNmdc("p", rawconn, true, true)
@@ -140,7 +140,7 @@ func (p *connPeer) do() {
 				}())
 
 			// if transfer is passive, we are the first to talk
-			if p.client.protoIsAdc == true {
+			if p.client.protoIsAdc() {
 				p.conn.Write(&msgAdcCSupports{
 					msgAdcTypeC{},
 					msgAdcKeySupports{map[string]struct{}{
@@ -323,7 +323,7 @@ func (p *connPeer) handleMessage(msgi msgDecodable) error {
 			// validate peer fingerprint
 			// can be performed on client-side only since many clients do not send
 			// their certificate when in passive mode
-			if p.client.protoIsAdc == true && p.isEncrypted == true &&
+			if p.client.protoIsAdc() && p.isEncrypted &&
 				p.peer.adcFingerprint != "" {
 
 				connFingerprint := adcCertificateFingerprint(

--- a/download.go
+++ b/download.go
@@ -235,7 +235,7 @@ func (d *Download) do() {
 				dolog(LevelDebug, "[download] [%s] requesting new connection", d.conf.Peer.Nick)
 
 				// generate new token
-				if d.client.protoIsAdc == true {
+				if d.client.protoIsAdc() {
 					d.adcToken = adcRandomToken()
 				}
 
@@ -265,7 +265,7 @@ func (d *Download) do() {
 		// process download
 		dolog(LevelInfo, "[download] [%s] processing", d.conf.Peer.Nick)
 
-		if d.client.protoIsAdc == true {
+		if d.client.protoIsAdc() {
 			d.pconn.conn.Write(&msgAdcCGetFile{
 				msgAdcTypeC{},
 				msgAdcKeyGetFile{

--- a/listener_tcp.go
+++ b/listener_tcp.go
@@ -40,7 +40,7 @@ func newListenerTcp(client *Client, isEncrypted bool) error {
 			return err
 		}
 
-		if client.protoIsAdc == true {
+		if client.protoIsAdc() {
 			xcert, err := x509.ParseCertificate(bcert)
 			if err != nil {
 				return err

--- a/listener_udp.go
+++ b/listener_udp.go
@@ -47,7 +47,7 @@ func (u *listenerUdp) do() {
 
 		u.client.Safe(func() {
 			err := func() error {
-				if u.client.protoIsAdc == true {
+				if u.client.protoIsAdc() {
 					if msgStr[len(msgStr)-1] != '\n' {
 						return fmt.Errorf("wrong terminator")
 					}

--- a/peer.go
+++ b/peer.go
@@ -63,7 +63,7 @@ func (c *Client) peerByClientId(clientId []byte) *Peer {
 }
 
 func (c *Client) peerSupportsEncryption(p *Peer) bool {
-	if c.protoIsAdc == true {
+	if c.protoIsAdc() {
 		if p.adcFingerprint != "" {
 			return true
 		}
@@ -87,7 +87,7 @@ func (c *Client) peerRequestConnection(peer *Peer, adcToken string) {
 }
 
 func (c *Client) peerConnectToMe(peer *Peer, adcToken string) {
-	if c.protoIsAdc == true {
+	if c.protoIsAdc() {
 		c.connHub.conn.Write(&msgAdcDConnectToMe{
 			msgAdcTypeD{c.sessionId, peer.adcSessionId},
 			msgAdcKeyConnectToMe{
@@ -123,7 +123,7 @@ func (c *Client) peerConnectToMe(peer *Peer, adcToken string) {
 }
 
 func (c *Client) peerRevConnectToMe(peer *Peer, adcToken string) {
-	if c.protoIsAdc == true {
+	if c.protoIsAdc() {
 		c.connHub.conn.Write(&msgAdcDRevConnectToMe{
 			msgAdcTypeD{c.sessionId, peer.adcSessionId},
 			msgAdcKeyRevConnectToMe{

--- a/search.go
+++ b/search.go
@@ -61,7 +61,7 @@ type searchIncomingRequest struct {
 
 // Search starts a file search asynchronously. See SearchConf for the available options.
 func (c *Client) Search(conf SearchConf) error {
-	if c.protoIsAdc == true {
+	if c.protoIsAdc() {
 		return c.handleAdcSearchOutgoingRequest(conf)
 	} else {
 		return c.handleNmdcSearchOutgoingRequest(conf)

--- a/share.go
+++ b/share.go
@@ -242,7 +242,7 @@ func (sm *shareIndexer) index() {
 		sm.client.shareSize = shareSize
 
 		// inform hub
-		if sm.client.connHub.terminateRequested == false && sm.client.connHub.state == "initialized" {
+		if sm.client.connHub.terminateRequested == false && sm.client.connHub.state == hubInitialized {
 			sm.client.sendInfos(false)
 		}
 

--- a/upload.go
+++ b/upload.go
@@ -143,7 +143,7 @@ func newUpload(client *Client, pconn *connPeer, reqQuery string, reqStart uint64
 	if err != nil {
 		dolog(LevelInfo, "[peer] cannot start upload: %s", err)
 		if err == errorNoSlots {
-			if u.client.protoIsAdc == true {
+			if u.client.protoIsAdc() {
 				u.pconn.conn.Write(&msgAdcCStatus{
 					msgAdcTypeC{},
 					msgAdcKeyStatus{
@@ -156,7 +156,7 @@ func newUpload(client *Client, pconn *connPeer, reqQuery string, reqStart uint64
 				u.pconn.conn.Write(&msgNmdcMaxedOut{})
 			}
 		} else {
-			if u.client.protoIsAdc == true {
+			if u.client.protoIsAdc() {
 				u.pconn.conn.Write(&msgAdcCStatus{
 					msgAdcTypeC{},
 					msgAdcKeyStatus{
@@ -172,7 +172,7 @@ func newUpload(client *Client, pconn *connPeer, reqQuery string, reqStart uint64
 		return false
 	}
 
-	if u.client.protoIsAdc == true {
+	if u.client.protoIsAdc() {
 		u.pconn.conn.Write(&msgAdcCSendFile{
 			msgAdcTypeC{},
 			msgAdcKeySendFile{


### PR DESCRIPTION
This PR adds new hooks, configuration options and ALPN.

* Add a hook for hub information like name, topic, description, etc.
* Call message hook for hub message on ADC.
* Allow setting a custom private ID.
* Enable ALPN to connect faster to hybrid hubs.
* Add hooks for TLS info and the protocol.
* Add missing `dchub` scheme for NMDC.
* Fix GoDoc for the client config.
* Change the type of hub connection state to enum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gswly/dctoolkit/5)
<!-- Reviewable:end -->
